### PR TITLE
Updated with comments from Byron

### DIFF
--- a/build_rsas_from_etas/main.gs
+++ b/build_rsas_from_etas/main.gs
@@ -175,7 +175,7 @@ function getAssets(accountName, accountId) {
   groupedAssets[adGroupId]['headlines'] = groupedAssets[adGroupId]['headlines'].filter(function(x) {return x.indexOf('{') !== -1;});
   groupedAssets[adGroupId]['descriptions'] = groupedAssets[adGroupId]['descriptions'].filter(function(x) {return x.indexOf('{') !== -1;});
 
-  Logger.log(Object.keys(groupedAssets).length + " ad groups have ETAs meeting criteria: ETA status = " + (pullFromPausedEtas ? "paused or enabled" : "enabled only"));
+  Logger.log(Object.keys(groupedAssets).length + " ad groups have ETAs meeting criteria: ETA status = " + (pullFromPausedEtas ? "paused or enabled." : "enabled only."));
 
   return groupedAssets;
 }

--- a/build_rsas_from_etas/main.gs
+++ b/build_rsas_from_etas/main.gs
@@ -15,7 +15,7 @@ var includePausedRsas = false;
 var pullFromPausedEtas = false;
 
 // Script entrypoint
-function main(){
+function main() {
   var executionContext = getExecutionContext();
   var topLevelAccountName = AdsApp.currentAccount().getName();
   var topLevelAccountId = AdsApp.currentAccount().getCustomerId();
@@ -170,6 +170,12 @@ function getAssets(accountName, accountId) {
     pushElementsIfNeeded(groupedAssets[adGroupId]['final_mobile_urls'], [finalMobileUrl]);
     
   }
+  
+  // Filter out ad customiser assets
+  groupedAssets[adGroupId]['headlines'] = groupedAssets[adGroupId]['headlines'].filter(function(x) {return x.indexOf('{') !== -1;});
+  groupedAssets[adGroupId]['descriptions'] = groupedAssets[adGroupId]['descriptions'].filter(function(x) {return x.indexOf('{') !== -1;});
+
+  
   
   return groupedAssets;
 }

--- a/build_rsas_from_etas/main.gs
+++ b/build_rsas_from_etas/main.gs
@@ -190,7 +190,7 @@ function writeToSheet(sheet, groupedAssets, maxNoOfAssets, accountName, accountI
 function setHeaders(sheet, maxNoAssets) {
   
   // Attribute headers
-  var headers = ["Account Name", "Account ID", "Campaign Name", "Campaign ID", "Ad Group Name", "Ad Group ID"];
+  var headers = ["Account", "Account ID", "Campaign", "Campaign ID", "Ad Group", "Ad Group ID"];
   var numColumns = headers.length;
   
   // Asset headers (of variable length)

--- a/build_rsas_from_etas/main.gs
+++ b/build_rsas_from_etas/main.gs
@@ -381,7 +381,7 @@ FROM \
 ad_group \
 WHERE \
 " + constraintsForQueries
-                       ).replace(/ +(?= )/g, '');
+).replace(/ +(?= )/g, '');
 
 var queryAdGroupsWithRsa = (" \
 SELECT \

--- a/build_rsas_from_etas/main.gs
+++ b/build_rsas_from_etas/main.gs
@@ -108,10 +108,10 @@ function getExecutionContext() {
 function getAssets(accountName, accountId) {
   Logger.log("Getting ad groups without RSAs...");
   var adGroupIdsWithoutRsas = getAdGroupIdsWithoutRsas();
-
+  
   Logger.log(adGroupIdsWithoutRsas.length + " ad groups found without RSAs.");
   if(adGroupIdsWithoutRsas.length === 0) {
-    Logger.log("No RSAs found in " + accountName + " (" + accountId + ").");
+    Logger.log("No ad groups without RSAs found in " + accountName + " (" + accountId + ").");
     return "no_rsas";
   }
 
@@ -175,7 +175,7 @@ function getAssets(accountName, accountId) {
   groupedAssets[adGroupId]['headlines'] = groupedAssets[adGroupId]['headlines'].filter(function(x) {return x.indexOf('{') !== -1;});
   groupedAssets[adGroupId]['descriptions'] = groupedAssets[adGroupId]['descriptions'].filter(function(x) {return x.indexOf('{') !== -1;});
 
-
+  Logger.log(Object.keys(groupedAssets).length + " ad groups have ETAs meeting criteria: ETA status = " + (pullFromPausedEtas ? "paused or enabled" : "enabled only"));
 
   return groupedAssets;
 }

--- a/build_rsas_from_etas/main.gs
+++ b/build_rsas_from_etas/main.gs
@@ -221,7 +221,7 @@ function setHeaders(sheet, maxNoAssets) {
   }
   numColumns += Math.max(1,maxNoAssets['max_path1s'], 1);
 
-  headers.push("Path 2(s)");
+  headers.push("Path 2");
   for (var i = 1; i < maxNoAssets['max_path2s']; i++) {
     headers.push("Additional Path 2");
   }

--- a/build_rsas_from_etas/main.gs
+++ b/build_rsas_from_etas/main.gs
@@ -22,43 +22,43 @@ function main() {
   var ssName = topLevelAccountName + " (" + topLevelAccountId + ") | ETA to RSA Builder";
   var ssMade = false;
   var ss = null;
-  
+
   // If MCC, run data process on a loop through all accounts
   if (executionContext === 'manager_account') {
     var accountIterator = AdsManagerApp.accounts().get();
     while(accountIterator.hasNext()) {
       AdsManagerApp.select(accountIterator.next());
-      
+
       var accountName = AdsApp.currentAccount().getName();
       var accountId = AdsApp.currentAccount().getCustomerId();
       var accountNameAndId = accountName + " (" + accountId + ")";  
-      
+
       Logger.log("Looking in account " + accountNameAndId + " ...");
       var assets = getAssets(accountName, accountId);
       if (assets !== 'no_rsas') {
-        
+
         if (ssMade === false) {
           Logger.log("Making Google Sheet...");
           ss = SpreadsheetApp.create(ssName);
           ssMade = true;
         }
-        
+
         var sheet = ss.insertSheet(accountNameAndId)
         var maxNoOfAssets = getMaxAssets(assets);
         writeToSheet(sheet, assets, maxNoOfAssets, accountName, accountId);
-        
+
       }
-      
+
       else if (assets === 'no_rsas' && accountIterator.hasNext()) {
         Logger.log("Trying next account...");
       }
       else if (assets === 'no_rsas' && !accountIterator.hasNext()) {
         Logger.log("No more accounts found. Terminating script.");
       }   
-       
+
       Logger.log("--------------------------------------------------");
     }
-    
+
     // Remove first sheet, which is blank
     ss.deleteSheet(ss.getSheets()[0]);
     if (ssMade === false) {
@@ -68,19 +68,19 @@ function main() {
       Logger.log("Script run complete. Google Sheet location: " + ss.getUrl());
     }
   }
-  
+
   // If child account, process on that account only
   else if (executionContext === 'client_account') {
     var accountName = AdsApp.currentAccount().getName();
     var accountId = AdsApp.currentAccount().getCustomerId();
     var accountNameAndId = accountName + " (" + accountId + ")";
-    
+
     var assets = getAssets(accountName, accountId);
     if (assets === 'no_rsas') {
       Logger.log("--------------------------------------------------");
       Logger.log("Script run complete. No ad groups missing RSAs found.");
     }
-    
+
     else if (assets !== 'no_rsas') {
       ss = SpreadsheetApp.create(ssName);
       var sheet = ss.getSheets()[0].setName(accountNameAndId);
@@ -98,33 +98,33 @@ function main() {
 
 // Determine the type of account in which the script is running
 function getExecutionContext() {
-    if (typeof AdsManagerApp != 'undefined') {
-        return 'manager_account';
-    }
-    return 'client_account';
+  if (typeof AdsManagerApp != 'undefined') {
+    return 'manager_account';
+  }
+  return 'client_account';
 }
 
 // Collect ETA assets and group by ad group ID
 function getAssets(accountName, accountId) {
   Logger.log("Getting ad groups without RSAs...");
   var adGroupIdsWithoutRsas = getAdGroupIdsWithoutRsas();
-  
+
   Logger.log(adGroupIdsWithoutRsas.length + " ad groups found without RSAs.");
   if(adGroupIdsWithoutRsas.length === 0) {
     Logger.log("No RSAs found in " + accountName + " (" + accountId + ").");
     return "no_rsas";
   }
-  
+
   var assetsQueryWithIds = assetsQueryTemplate.replace("*INSERT_AD_GROUP_IDS*", adGroupIdsWithoutRsas.join(","));
   Logger.log("Getting ETAs from ad groups without RSAs...");
   var assetsReport = AdsApp.search(assetsQueryWithIds);
-  
+
   var groupedAssets = {};
-  
+
   Logger.log("Extracting assets...");
   while(assetsReport.hasNext()) {
     var reportRow = assetsReport.next();
-    
+
     // Attributes  
     var adGroupId = reportRow.adGroup.id;
     var adGroupName = reportRow.adGroup.name;
@@ -142,13 +142,13 @@ function getAssets(accountName, accountId) {
     var path1 = reportRow.adGroupAd.ad.expandedTextAd.path1;
     var path2 = reportRow.adGroupAd.ad.expandedTextAd.path2;
     var finalUrl = reportRow.adGroupAd.ad.finalUrls[0];
-    
+
     // Mobile URL not always present
     var finalMobileUrl = "";
     if (reportRow.adGroupAd.ad.finalMobileUrls) {
       var finalMobileUrl = reportRow.adGroupAd.ad.finalMobileUrls[0];
     }
-     
+
     groupedAssets[adGroupId] = groupedAssets[adGroupId] || {
       'ad_group_id': adGroupId,
       'ad_group_name': adGroupName,
@@ -160,23 +160,23 @@ function getAssets(accountName, accountId) {
       'path2s': [],
       'final_urls': [],
       'final_mobile_urls': []
-     };
-    
+    };
+
     pushElementsIfNeeded(groupedAssets[adGroupId]['headlines'], [headline1, headline2, headline3]);
     pushElementsIfNeeded(groupedAssets[adGroupId]['descriptions'], [description1, description2]);
     pushElementsIfNeeded(groupedAssets[adGroupId]['path1s'], [path1]);
     pushElementsIfNeeded(groupedAssets[adGroupId]['path2s'], [path2]);
     pushElementsIfNeeded(groupedAssets[adGroupId]['final_urls'], [finalUrl]);
     pushElementsIfNeeded(groupedAssets[adGroupId]['final_mobile_urls'], [finalMobileUrl]);
-    
+
   }
-  
+
   // Filter out ad customiser assets
   groupedAssets[adGroupId]['headlines'] = groupedAssets[adGroupId]['headlines'].filter(function(x) {return x.indexOf('{') !== -1;});
   groupedAssets[adGroupId]['descriptions'] = groupedAssets[adGroupId]['descriptions'].filter(function(x) {return x.indexOf('{') !== -1;});
 
-  
-  
+
+
   return groupedAssets;
 }
 
@@ -188,76 +188,87 @@ function writeToSheet(sheet, groupedAssets, maxNoOfAssets, accountName, accountI
 
 // Set headers in a sheet
 function setHeaders(sheet, maxNoAssets) {
-  
+
   // Attribute headers
   var headers = ["Account", "Account ID", "Campaign", "Campaign ID", "Ad Group", "Ad Group ID"];
   var numColumns = headers.length;
-  
+
   // Asset headers (of variable length)
   for (var i = 0; i < maxNoAssets['max_headlines']; i++) {
-    headers.push("Headline " + (i+1));
+    if ((i+1) <= 15) {
+      headers.push("Headline " + (i+1));
+    }
+    else if ((i+1) > 15) {
+      headers.push("Additional Headline");
+    }
   }
+
   numColumns += maxNoAssets['max_headlines'];
-  
+
   for (var i = 0; i < maxNoAssets['max_descriptions']; i++) {
-    headers.push("Description " + (i+1));
+    if ((i+1) <= 4) {
+      headers.push("Description " + (i+1));
+    }
+    else if ((i+1) > 4) {
+      headers.push("Additional Description");
+    }
   }
   numColumns += maxNoAssets['max_descriptions'];
 
-  headers.push("Path 1(s)");
+  headers.push("Path 1");
   for (var i = 1; i < maxNoAssets['max_path1s']; i++) {
-    headers.push("...");
+    headers.push("Additional Path 1");
   }
   numColumns += Math.max(1,maxNoAssets['max_path1s'], 1);
-  
+
   headers.push("Path 2(s)");
   for (var i = 1; i < maxNoAssets['max_path2s']; i++) {
-    headers.push("...");
+    headers.push("Additional Path 2");
   }
   numColumns += Math.max(1,maxNoAssets['max_path2s'], 1);
- 
-  headers.push("Final URL(s)");
+
+  headers.push("Final URL");
   for (var i = 1; i < maxNoAssets['max_urls']; i++) {
-    headers.push("...");
+    headers.push("Additional Final URL");
   }
   numColumns += Math.max(1, maxNoAssets['max_urls']);
-  
-  headers.push("Final Mobile URL(s)");
+
+  headers.push("Final Mobile URL");
   for (var i = 1; i < maxNoAssets['max_mobile_urls']; i++) {
-    headers.push("...");
+    headers.push("Additional Final Mobile URL");
   }
   numColumns += Math.max(1, maxNoAssets['max_mobile_urls']);
-  
+
   // Font weight row to allow us to set the headers to bold
   var boldings = [];
   for (var i = 0; i < numColumns; i++) {
     boldings.push("bold");
   }
-  
+
   // Set values and bolding
   sheet.getRange(1, 1, 1, numColumns).setValues([headers]).setFontWeights([boldings]);
-  
+
   return null;
 }
 
 // Set outputs for sheet
 function pushDataToSheet(sheet, groupedAssets, maxNoAssets, accountName, accountId) {
   Logger.log("Pushing to sheet...");
-  
+
   var outputData = [];
-  
+
   for (var adGroupId in groupedAssets) {
     var data = groupedAssets[adGroupId];
-    
+
     var row = [accountName, accountId, data['campaign_name'], data['campaign_id'], data['ad_group_name'], data['ad_group_id']];
-    
+
     // For each type of asset, must blank fill columns where the ad group has less than the maximum number of that asset type
     // This ensures columns all line up with their headers
     row.push.apply(row, data['headlines'])
     for (var i = data['headlines'].length; i < maxNoAssets['max_headlines']; i++) {
       row.push("");
     }
-    
+
     row.push.apply(row, data['descriptions'])
     for (var i = data['descriptions'].length; i < maxNoAssets['max_descriptions']; i++) {
       row.push("");
@@ -278,14 +289,14 @@ function pushDataToSheet(sheet, groupedAssets, maxNoAssets, accountName, account
     for (var i = data['final_mobile_urls'].length; i < maxNoAssets['max_mobile_urls']; i++) {
       row.push("");
     }
-    
+
     outputData.push(row);
   }
-  
+
   // Push to sheet and autosize columns
   sheet.getRange(2, 1, outputData.length, outputData[0].length).setValues(outputData);
   sheet.autoResizeColumns(1, outputData[0].length);
-  
+
   return null;
 }
 
@@ -293,7 +304,7 @@ function pushDataToSheet(sheet, groupedAssets, maxNoAssets, accountName, account
 function pushElementsIfNeeded(arr, elements) {
   for (var i = 0; i < elements.length; i++) {
     var el = elements[i]; 
-    
+
     if (arr.indexOf(el) === -1 && el) {
       arr.push(el);
     }
@@ -312,7 +323,7 @@ function getMaxAssets(obj) {
     'max_urls': 0,
     'max_mobile_urls': 0
   }
-  
+
   for (var adGroupId in obj) {
     maxs['max_headlines'] = Math.max(maxs['max_headlines'], obj[adGroupId]['headlines'].length);
     maxs['max_descriptions'] = Math.max(maxs['max_descriptions'], obj[adGroupId]['descriptions'].length);
@@ -321,34 +332,34 @@ function getMaxAssets(obj) {
     maxs['max_urls'] = Math.max(maxs['max_urls'], obj[adGroupId]['final_urls'].length);
     maxs['max_mobile_urls'] = Math.max(maxs['max_mobile_urls'], obj[adGroupId]['final_mobile_urls'].length);
   }
-  
+
   return maxs;
 }
 
 // Returns a list of Ad Group IDs that correspond to a given condition
 function getAdGroupsWithCondition(condition) {
-    var query = adGroupQueries[condition];
-    var ids = [];
+  var query = adGroupQueries[condition];
+  var ids = [];
 
-    var iterator = AdsApp.report(query).rows();
-    while (iterator.hasNext()) {
-        var row = iterator.next();
-        ids.push(row['ad_group.id']);
-    }
+  var iterator = AdsApp.report(query).rows();
+  while (iterator.hasNext()) {
+    var row = iterator.next();
+    ids.push(row['ad_group.id']);
+  }
 
-    return ids;
+  return ids;
 }
 
 // Process to extract entities without RSAs from a given account
 function getAdGroupIdsWithoutRsas() {
 
-    var allAdGroupIds = getAdGroupsWithCondition('all_ad_groups');
-    var adGroupIdsWithRsa = getAdGroupsWithCondition('ad_groups_with_rsas');
-    var adGroupIdsWithoutRsa = allAdGroupIds.filter(function(id) {
-        return adGroupIdsWithRsa.indexOf(id) === -1
-    });
-  
-    return adGroupIdsWithoutRsa;
+  var allAdGroupIds = getAdGroupsWithCondition('all_ad_groups');
+  var adGroupIdsWithRsa = getAdGroupsWithCondition('ad_groups_with_rsas');
+  var adGroupIdsWithoutRsa = allAdGroupIds.filter(function(id) {
+    return adGroupIdsWithRsa.indexOf(id) === -1
+  });
+
+  return adGroupIdsWithoutRsa;
 }
 
 // ========= GAQL QUERIES ==============================================================================================
@@ -356,49 +367,49 @@ function getAdGroupIdsWithoutRsas() {
 var today = Utilities.formatDate(new Date(), AdsApp.currentAccount().getTimeZone(), "yyyy-MM-dd");
 
 var constraintsForQueries = (" \
-    campaign.advertising_channel_type = 'SEARCH' \
-    AND ad_group.type IN ('SEARCH_STANDARD') \
-    AND campaign.status IN ('ENABLED'" + (checkPausedCampaigns ? ", 'PAUSED'" : "") + ") \
-    AND ad_group.status IN ('ENABLED'" + (checkPausedAdGroups ? ", 'PAUSED'" : "") + ") \
-    AND campaign.end_date >= '" + today + "'"
+campaign.advertising_channel_type = 'SEARCH' \
+AND ad_group.type IN ('SEARCH_STANDARD') \
+AND campaign.status IN ('ENABLED'" + (checkPausedCampaigns ? ", 'PAUSED'" : "") + ") \
+AND ad_group.status IN ('ENABLED'" + (checkPausedAdGroups ? ", 'PAUSED'" : "") + ") \
+AND campaign.end_date >= '" + today + "'"
 );
 
 var queryAllAdGroups = (" \
-    SELECT \
-        ad_group.id \
-    FROM \
-        ad_group \
-    WHERE \
-        " + constraintsForQueries
-  ).replace(/ +(?= )/g, '');
+SELECT \
+ad_group.id \
+FROM \
+ad_group \
+WHERE \
+" + constraintsForQueries
+                       ).replace(/ +(?= )/g, '');
 
 var queryAdGroupsWithRsa = (" \
-    SELECT \
-        ad_group.id \
-    FROM \
-        ad_group_ad \
-    WHERE \
-        " + constraintsForQueries + " \
-        AND ad_group_ad.status IN ('ENABLED'" + (includePausedRsas ? ", 'PAUSED'" : "") + ") \
-        AND ad_group_ad.ad.type = 'RESPONSIVE_SEARCH_AD'"
-  ).replace(/ +(?= )/g, '');
+SELECT \
+ad_group.id \
+FROM \
+ad_group_ad \
+WHERE \
+" + constraintsForQueries + " \
+AND ad_group_ad.status IN ('ENABLED'" + (includePausedRsas ? ", 'PAUSED'" : "") + ") \
+AND ad_group_ad.ad.type = 'RESPONSIVE_SEARCH_AD'"
+).replace(/ +(?= )/g, '');
 
 var assetsQueryTemplate = (" \
-  SELECT \
-    ad_group_ad.ad.expanded_text_ad.headline_part1, ad_group_ad.ad.expanded_text_ad.headline_part2, ad_group_ad.ad.expanded_text_ad.headline_part3, \
-    ad_group_ad.ad.expanded_text_ad.description, ad_group_ad.ad.expanded_text_ad.description2, \
-    ad_group_ad.ad.expanded_text_ad.path1, ad_group_ad.ad.expanded_text_ad.path2, \
-    ad_group_ad.ad.final_urls, ad_group_ad.ad.final_mobile_urls, \
-    campaign.name, campaign.id, ad_group.name, ad_group.id \
-  FROM \
-    ad_group_ad \
-  WHERE \
-    ad_group.id IN (*INSERT_AD_GROUP_IDS*) \
-    AND ad_group_ad.ad.type = 'EXPANDED_TEXT_AD' \
-    AND ad_group_ad.status IN ('ENABLED'" + (pullFromPausedEtas ? ", 'PAUSED'" : "") + ")"
+SELECT \
+ad_group_ad.ad.expanded_text_ad.headline_part1, ad_group_ad.ad.expanded_text_ad.headline_part2, ad_group_ad.ad.expanded_text_ad.headline_part3, \
+ad_group_ad.ad.expanded_text_ad.description, ad_group_ad.ad.expanded_text_ad.description2, \
+ad_group_ad.ad.expanded_text_ad.path1, ad_group_ad.ad.expanded_text_ad.path2, \
+ad_group_ad.ad.final_urls, ad_group_ad.ad.final_mobile_urls, \
+campaign.name, campaign.id, ad_group.name, ad_group.id \
+FROM \
+ad_group_ad \
+WHERE \
+ad_group.id IN (*INSERT_AD_GROUP_IDS*) \
+AND ad_group_ad.ad.type = 'EXPANDED_TEXT_AD' \
+AND ad_group_ad.status IN ('ENABLED'" + (pullFromPausedEtas ? ", 'PAUSED'" : "") + ")"
 ).replace(/ +(?= )/g, '');
 
 var adGroupQueries = {
-    'all_ad_groups': queryAllAdGroups,
-    'ad_groups_with_rsas': queryAdGroupsWithRsa
+  'all_ad_groups': queryAllAdGroups,
+  'ad_groups_with_rsas': queryAdGroupsWithRsa
 };


### PR DESCRIPTION
## Purpose

> [Required] Updated with comments from Byron. Changes mostly involve tweaks to output headers or logs.


## Background

> [Optional] Points flagged by Byron which have now been reviewed with changes made as necessary:

- Script doesn't run on new beta - _false, looks like Byron is mistaken and will ask him to check again_
- Filter any ETA assets using ad customisers out of output - _done by checking whether `{` is present in ad copy (this necessarily means that the asset is using an ad customiser_
- Change headers in output sheet so that they don't need changing before uploading to Editor - _done, headers now align with Editor columns, columns with optional assets start 'Additional'_
- Number given in `x ad groups found without RSAs` did not align with number of rows in output sheet - _some ad groups have no ETAs meeting criteria, so don't correspond to a row in the output sheet. New logging introduced to make this clearer_

## Solution

> [Optional] See 'background'

## Callouts to review

> [Optional] N/A, should be pretty straightforward

## Checklist

> [Required] You should review the points in this checklist before requesting a review.
> 
> Note: put **x** in each `[ ]` to mark as completed and use `~~` to cross out irrelevant points.

- [x] The PR message has been filled out appropriately.
- ~[ ] Any relevant CI processes are running successfully.~
- [x] Commit messages are well structured and explain what/why changes are made.
- [x] A well-structured readme exists that conforms to repo standards.
- [x] Docstrings have been used comprehensively and inline comments where needed.
- [x] Code has been structured with testability, readability, edge cases and errors in mind.
- ~[ ] Enviornmental differences have been implemented according to repo standards.~
- ~[ ] Appropriate testing has been added (unit > integration > end-to-end).~
- [x] Observability and monitoring has been considered.
- ~[ ] Information security has been considered.~
- ~[ ] _(If relevant)_ New infrastructure has been provisioned.~
- ~[ ] _(If relevant)_ New process alerting has been set up. ~