### PR TITLE
MCC Support

### DIFF
--- a/performance_decomposition/google_ads/google_ads_exports.gs
+++ b/performance_decomposition/google_ads/google_ads_exports.gs
@@ -1,29 +1,42 @@
-/************* USER CONFIGS *********************************************************************************************/
+/************* GENERAL CONFIGS **************************************************************************************************************/
 
 // URL of spreadsheet
-const SPREADSHEET_URL = "XXXXXX";
+const SPREADSHEET_URL = "XXXX";
 
 // Number of days of data to include in export
 const REPORTING_WINDOW = 180;
 
-/************************************************************************************************************************/
-/************* DO NOT EDIT BELOW THIS LINE ******************************************************************************/
-/************************************************************************************************************************/
+/************* MCC CONFIGS ******************************************************************************************************************/
 
-/************* MAIN FUNCTION ********************************************************************************************/
+// To filter which child accounts to pull data from, enter them below in ONE of the below
+// To only pull data from specific accounts, add them to ACCOUNTS_TO_INCLUDE
+// To pull data from all accounts except specific ones, add them to ACCOUNTS_TO_EXCLUDE
+// Lists should be comma separated account IDs with dashses, enclosed in quotes
+// E.g. ['123-456-7890', '345-6789-0123']
+
+const ACCOUNTS_TO_INCLUDE = [];
+const ACCOUNTS_TO_EXCLUDE = [];
+
+/********************************************************************************************************************************************/
+/************* DO NOT EDIT BELOW THIS LINE **************************************************************************************************/
+/********************************************************************************************************************************************/
+
+/************* SCRIPT ENTRY POINT ***********************************************************************************************************/
 
 function main() {
+  const isMcc = typeof AdsManagerApp == "undefined" ? false : true;
+  
   const reportStart = getDateXDaysAgo(REPORTING_WINDOW);
-  const yesterday = getDateXDaysAgo(1)
+  const yesterday = getDateXDaysAgo(1);
   const queriesConfig = [
     {
       name: "BASE_METRICS_PERFORMANCE_QUERY",
-      queryTemplate: BASE_METRICS_PERFORMANCE_QUERY_TEMPLATE,
+      query: `${BASE_METRICS_PERFORMANCE_QUERY_TEMPLATE} '${reportStart}' AND '${yesterday}'`,
       sheetName: "Google Ads Import: Google Ads Campaign Stats"
     },
     {
       name: "CONVERSION_PERFORMANCE_QUERY",
-      queryTemplate: CONVERSION_PERFORMANCE_QUERY_TEMPLATE,
+      query: `${CONVERSION_PERFORMANCE_QUERY_TEMPLATE} '${reportStart}' AND '${yesterday}'`,
       sheetName: "Google Ads Import: Google Ads Campaign Conv. Stats"
     },
   ];
@@ -31,34 +44,79 @@ function main() {
   const spreadsheet = SpreadsheetApp.openByUrl(SPREADSHEET_URL);
   Logger.log(`Loaded config and connected to spreadsheet ${spreadsheet.getName()}.`);
 
-  Logger.log("Iterating through queries...");
+  const reportsBySheetName = initialiseReports(queriesConfig);
+  
+  if (isMcc) {
+    const accountIterator = getAccountsToReportOn(ACCOUNTS_TO_INCLUDE, ACCOUNTS_TO_EXCLUDE);
+    while (accountIterator.hasNext()) {
+      let account = accountIterator.next();
+      AdsManagerApp.select(account);
+      accountMain(account, queriesConfig, reportsBySheetName);
+    }
+
+    Logger.log('Finished iterating.')
+  }
+
+  if (!isMcc) {
+    accountMain(AdsApp.currentAccount(), queriesConfig, reportsBySheetName);
+  }
+
+  Logger.log('Exporting data to Google Sheet...')
+  exportToSheet(reportsBySheetName, spreadsheet);
+  Logger.log('Terminating.');
+
+  return null;
+}
+
+/************* UTILITY FUNCTIONS ************************************************************************************************************/
+
+// Run each query in a given account and export the results to a G Sheet
+function accountMain(account, queriesConfig, reportsBySheetName) {
+  Logger.log(`* Iterating through queries in account: ${account.getName()} (${account.getCustomerId()})...`);
 
   for (let i = 0; i < queriesConfig.length; i++) {    
     const config = queriesConfig[i];
-    Logger.log(`Processing query ${config.name}...`);
+    Logger.log(`  * Processing query ${config.name}...`);
 
-    const query = `${config.queryTemplate} '${reportStart}' AND '${yesterday}'`;
+    const query = config.query;
+    const reportRows = AdsApp.report(query).rows();
+    const headers = reportsBySheetName[config.sheetName]['headerOrder'];
+    
+    while (reportRows.hasNext()) {
+      let row = reportRows.next();
 
-    const sheet = getOrCreateSheet(spreadsheet, config.sheetName);
-    getReportToSheet(query, sheet);
-    sheet.hideSheet();
-
-    Logger.log(`Exported ${config.name}.`);
+      // Store query results by sheet and add each metric under its header
+      for (let i = 0; i < headers.length; i++) {
+         const header = headers[i];
+         reportsBySheetName[config.sheetName][header].push(row[header]);
+      }
+    }
   }
-
-  Logger.log("Finished iterating.");
-  Logger.log("Terminating.");
-
+  
+  return null;
 }
 
-/************* UTILITY FUNCTIONS ******************************************************************************************/
+// Export reports to sheet from objects of reports ordered by sheet name
+function exportToSheet(reportsBySheetName, spreadsheet) {
+      
+  for (let sheetName in reportsBySheetName) {
+      const sheet = getOrCreateSheet(spreadsheet, sheetName);
+      sheet.clear();
+      const reports = reportsBySheetName[sheetName];
 
-// Pull a GAQL report and export it to a tab in a Google Sheet
-function getReportToSheet(query, sheet) {
-  const report = AdsApp.report(query);
+      // Write to sheet column by column due to format of reportsBySheetName object
+      for (let i = 0; i < reports['headerOrder'].length; i++) {
+        const currentHeader = reports['headerOrder'][i];
+        let column = [[currentHeader]];
+        const columnValues = reports[currentHeader].map(el => [el]);                // Store each value within an Array so it can be output to G Sheet
+        column = column.concat(columnValues);
+        sheet.getRange(1, i + 1, column.length, 1).setValues(column);
+      }
 
-  sheet.clear();
-  report.exportToSheet(sheet);
+      sheet.hideSheet();
+  }
+  
+  return null;
 }
 
 // Get a sheet by name, or create and colour-code the sheet if it does not exist
@@ -66,7 +124,7 @@ function getOrCreateSheet(spreadsheet, sheetName) {
   let sheet = spreadsheet.getSheetByName(sheetName);
 
   if (sheet !== null) {
-    Logger.log(`Found sheet: ${sheetName}.`);
+    Logger.log(`  * Found sheet: ${sheetName}.`);
 
     return sheet;
   }
@@ -89,7 +147,93 @@ function getDateXDaysAgo(lookbackWindow) {
   return Utilities.formatDate(dateXDaysAgo, AdsApp.currentAccount().getTimeZone(), "yyyy-MM-dd");
 }
 
-/************* GAQL QUERIES *********************************************************************************************/
+// Validate MCC configs and return iterator of accounts to report on
+function getAccountsToReportOn(accountsToInclude, accountsToExclude) {
+  if (accountsToInclude.length > 0 && accountsToExclude.length > 0) {
+    throw new Error("Only one of ACCOUNTS_TO_INCLUDE, ACCOUNTS_TO_EXCLUDE should be filled. The other must be empty.");
+  }
+
+  else if (accountsToInclude.length === 0 && accountsToExclude.length === 0) {
+    return AdsManagerApp.accounts().get();
+  }
+
+  else if (accountsToInclude.length > 0 && accountsToExclude.length === 0) {
+    validateAccountLists(accountsToInclude, 'ACCOUNTS_TO_INCLUDE');
+    return AdsManagerApp.accounts().withIds(accountsToInclude).get();
+  }
+
+  else if (accountsToInclude.length === 0 && accountsToExclude.length > 0) {
+    validateAccountLists(accountsToExclude, 'ACCOUNTS_TO_EXCLUDE');
+    const invertedIds = changeAccountExclusionToInclusion(accountsToExclude);
+
+    return AdsManagerApp.accounts().withIds(invertedIds).get();
+  }
+
+}
+
+// Validate that account IDs in an array are of the form XXX-XXX-XXXX
+function validateAccountLists(ids, listName) {
+  const checkIndividualElement = (el) => /^\d{3}\-\d{3}\-\d{4}$/.test(el);
+  const allCorrectForm = ids.every(checkIndividualElement);
+
+  if (allCorrectForm) {
+    Logger.log(`Account IDs in list ${listName} of the correct form.`);
+  }
+
+  else if (!allCorrectForm) {
+    const malformedIds = ids.filter((el) => !checkIndividualElement(el));
+    throw new Error(`The following account IDs in the list ${listName} are incorrectly formatted: ${malformedIds}. \
+Please ensure IDs are entered as a comma-separated list of the form XXX-XXX-XXXX`);
+  }
+
+
+}
+
+// Get the column headers from a raw GAQL query as an array
+// TODO: Tests
+function getHeaders(query) {
+  const formattedQuery = query.replace(/\s+/g, " ").replace(/^ /, "").replace(/ $/, "");
+  const headerString = /^SELECT (.*) FROM.*$/g.exec(formattedQuery)[1];
+  
+  return headerString.split(', ');
+}
+
+// Initialise form of report as {sheetName1: {header1: [], header2: [], ...}, ...}
+// TODO: Tests
+function initialiseReports(queriesConfig) {
+  const reportsBySheetName = {};
+  
+  for (let i = 0; i < queriesConfig.length; i++) {
+    const config = queriesConfig[i];
+    const queryHeaders = getHeaders(config.query);
+    reportsBySheetName[config.sheetName] = {};
+    reportsBySheetName[config.sheetName]['headerOrder'] = queryHeaders;
+    queryHeaders.forEach(h => reportsBySheetName[config.sheetName][h] = []);
+  }
+  
+  return reportsBySheetName;
+}
+
+// Get IDs of accounts which are in MCC but not in accountsToExclude
+// For use with .withIds() function when selecting child accounts
+// TODO: Tests
+function changeAccountExclusionToInclusion(accountsToExclude) {
+  const accountsToInclude = [];
+
+  const accountsIterator = AdsManagerApp.accounts().get();
+
+  while(accountsIterator.hasNext()) {
+    let customerId = accountsIterator.next().getCustomerId();
+
+    if (accountsToExclude.indexOf(customerId) === -1) {
+      accountsToInclude.push(customerId);
+    }
+  }
+
+  return accountsToInclude;
+}
+
+/************* GAQL QUERIES *****************************************************************************************************************/
 
 // NB: The WHERE clauses must be completed with dates before using
 

--- a/performance_decomposition/google_ads/google_ads_exports.gs
+++ b/performance_decomposition/google_ads/google_ads_exports.gs
@@ -23,7 +23,7 @@ const ACCOUNTS_TO_EXCLUDE = [];
 
 /************* SCRIPT ENTRY POINT ***********************************************************************************************************/
 
-function main() {
+function main2() {
   const isMcc = typeof AdsManagerApp == "undefined" ? false : true;
   
   const reportStart = getDateXDaysAgo(REPORTING_WINDOW);
@@ -190,7 +190,6 @@ Please ensure IDs are entered as a comma-separated list of the form XXX-XXX-XXXX
 }
 
 // Get the column headers from a raw GAQL query as an array
-// TODO: Tests
 function getHeaders(query) {
   const formattedQuery = query.replace(/\s+/g, " ").replace(/^ /, "").replace(/ $/, "");
   const headerString = /^SELECT (.*) FROM.*$/g.exec(formattedQuery)[1];
@@ -199,7 +198,6 @@ function getHeaders(query) {
 }
 
 // Initialise form of report as {sheetName1: {header1: [], header2: [], ...}, ...}
-// TODO: Tests
 function initialiseReports(queriesConfig) {
   const reportsBySheetName = {};
   
@@ -216,7 +214,6 @@ function initialiseReports(queriesConfig) {
 
 // Get IDs of accounts which are in MCC but not in accountsToExclude
 // For use with .withIds() function when selecting child accounts
-// TODO: Tests
 function changeAccountExclusionToInclusion(accountsToExclude) {
   const accountsToInclude = [];
 

--- a/performance_decomposition/google_ads/google_ads_tests
+++ b/performance_decomposition/google_ads/google_ads_tests
@@ -1,0 +1,145 @@
+/** Note: To run the test suite, you must rename the main() function to something else so that this main() can run **/
+
+function main() {
+ runAllTests(); 
+}
+
+/******************* TEST CASES ********************************************************************************************/
+// 2 element Array:
+// * First element is an array containing arguments for function
+// * Second element is expected result
+const getHeadersCases = [
+  [`
+SELECT 
+  segments.date, 
+  customer.id,
+  customer.descriptive_name,
+  customer.currency_code,
+  campaign.id,
+  campaign.name, 
+  metrics.cost_micros, 
+  metrics.search_impression_share,
+  metrics.impressions, 
+  metrics.clicks
+FROM 
+  campaign 
+WHERE 
+  segments.date BETWEEN
+`,
+  ['segments.date', 'customer.id', 'customer.descriptive_name', 'customer.currency_code', 'campaign.id', 'campaign.name', 'metrics.cost_micros', 'metrics.search_impression_share', 'metrics.impressions', 'metrics.clicks']],
+  [`
+SELECT
+  campaign.name
+FROM
+  campaign
+WHERE
+  segments.date DURING LAST_7_DAYS
+  `,
+  ['campaign.name']],
+];
+
+const initialiseReportsCases = [
+    [
+        [
+            {
+                name: "BASE_METRICS_PERFORMANCE_QUERY",
+                query: "SELECT metrics.impressions, metrics.clicks FROM campaign WHERE segments.date BETWEEN '2022-01-01' AND '2021-02-01'",
+                sheetName: "Google Ads Import: Google Ads Campaign Stats"
+            },
+            {
+                name: "CONVERSION_PERFORMANCE_QUERY",
+                query: "SELECT metrics.all_conversions, metrics.all_conversions_value FROM campaign WHERE segments.date BETWEEN '2022-01-01' AND '2021-02-01'",
+                sheetName: "Google Ads Import: Google Ads Campaign Conv. Stats"
+            },
+        ],
+        {
+            "Google Ads Import: Google Ads Campaign Stats": {
+                "headerOrder": ['metrics.impressions', 'metrics.clicks'],
+                "metrics.impressions": [],
+                "metrics.clicks": [],
+            },
+            "Google Ads Import: Google Ads Campaign Conv. Stats": {
+                "headerOrder": ['metrics.all_conversions', 'metrics.all_conversions_value'],
+                "metrics.all_conversions": [],
+                "metrics.all_conversions_value": [],
+            }
+        }
+    ]
+];
+
+/******************* TEST SUITE ********************************************************************************************/
+
+// Keep track of no. of tests passed and failed
+let tally = {"passed": 0, "failed": 0}
+
+/**
+ * Basic assert function
+ * @param {function} func function to be tests
+ * @param {Any} args arguments for func
+ * @param {String} expectedResult value the test should return
+ * @return {String} whether test passed or failed
+ */
+// TODO: Make log/warning not show function arguments inside square brackets
+function assert(func, args, expectedResult) {
+  const actualResult = func(...[args]);
+  
+  if(actualResult === expectedResult && typeof actualResult === typeof expectedResult) {
+    console.log(`Test passed: ${func.name}(${args}) = ${expectedResult}`);
+    return "passed";
+  }
+  
+  else if (typeof actualResult === typeof expectedResult && typeof actualResult === 'object') {
+    if (JSON.stringify(actualResult) === JSON.stringify(expectedResult)) {
+        console.log(`Test passed: ${func.name}(${args}) = ${expectedResult}`);
+        return "passed";
+    }
+    
+    else if (JSON.stringify(actualResult) !== JSON.stringify(expectedResult)) {
+    console.warn(`Test failed: ${func.name}(${args}) =/= ${expectedResult}\n\n\n
+Expected: ${expectedResult}\n\n
+Actual: ${actualResult}`);
+    return "failed";    }
+  }
+  
+  else if (typeof actualResult !== typeof expectedResult) {
+    console.warn(`Test failed: mismatched types.
+Expected: ${typeof expectedResult}
+Actual: ${actualResult}`);
+    
+    return "failed";
+  }
+  
+  else if(actualResult !== expectedResult) {
+
+    console.warn(`Test failed: ${func.name}(`, args, `) =/= ${expectedResult}
+Expected: ${expectedResult}
+Actual: ${actualResult}`);
+    return "failed";
+  }
+  
+}
+
+function runMultipleTests(func, cases) {
+  Logger.log("** Testing " + func.name + " **");
+
+  for (let i = 0; i < cases.length; i++) {
+    const funcArgs = cases[i][0]
+    const expectedResult = cases[i][1];
+
+    let result = assert(func, funcArgs, expectedResult);
+    tally[result]++
+  }
+
+  Logger.log("** Finished testing " + func.name + " **");
+}
+/**
+ * Function to run multiple test cases using runMultipleTests
+ */
+function runAllTests() {
+  runMultipleTests(getHeaders, getHeadersCases);
+  runMultipleTests(initialiseReports, initialiseReportsCases);
+
+  Logger.log(`Passed: ${tally["passed"]}, Failed: ${tally["failed"]}`);
+
+  return null;
+}


### PR DESCRIPTION
MCC account support for the Google Ads script. Had to refactor a decent amount of the code since I couldn't use some of the nice tricks like `.exportToSheet()` when iterating through multiple accounts.

The script now goes through each account and pulls the reports into an object which stores the results of the query under the name of the sheet it is being exported to. I've had to output the reports column by column in each sheet, otherwise it's excessively fiddly to combine together reports across multiple different accounts. The script still runs in under a minute, so no concerns around efficiency.

There are also new user settings to either specify an exclusive list of accounts to include from an MCC, or an exclusive list of accounts to exclude. This should help users prevent accounts they don't want pulling into the sheet and clogging up the options.

I've also added in testing. There are only 2 methods that are feasible to test/need testing.